### PR TITLE
Fix get_user_by_email empty result handling

### DIFF
--- a/.github/workflows/backend-unit-tests.yml
+++ b/.github/workflows/backend-unit-tests.yml
@@ -1,0 +1,35 @@
+name: Backend unit tests
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  backend-unit-tests:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: backend
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install backend dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest pytest-cov pymongo python-dotenv flask flask-cors bson
+
+      - name: Run backend unit tests
+        run: |
+          python -m pytest test/demo/test_usercontroller_get_user_by_email.py -v

--- a/backend/src/controllers/usercontroller.py
+++ b/backend/src/controllers/usercontroller.py
@@ -4,17 +4,18 @@ from src.util.dao import DAO
 import re
 emailValidator = re.compile(r'.*@.*')
 
+
 class UserController(Controller):
     def __init__(self, dao: DAO):
         super().__init__(dao=dao)
 
     def get_user_by_email(self, email: str):
-        """Given a valid email address of an existing account, return the user object contained in the database associated 
+        """Given a valid email address of an existing account, return the user object contained in the database associated
         to that user. For now, do not assume that the email attribute is unique. Additionally print a warning message containing the email
         address if the search returns multiple users.
-        
+
         parameters:
-            email -- an email address string 
+            email -- an email address string
 
         returns:
             user -- the user object associated to that email address (if multiple users are associated to that email: return the first one)
@@ -30,11 +31,14 @@ class UserController(Controller):
 
         try:
             users = self.dao.find({'email': email})
-            if len(users) == 1:
-                return users[0]
-            else:
+
+            if len(users) == 0:
+                return None
+
+            if len(users) > 1:
                 print(f'Error: more than one user found with mail {email}')
-                return users[0]
+
+            return users[0]
         except Exception as e:
             raise
 

--- a/backend/test/demo/test_dao_create_integration.py
+++ b/backend/test/demo/test_dao_create_integration.py
@@ -1,0 +1,72 @@
+import uuid
+import pymongo
+import pytest
+from unittest.mock import patch
+
+from src.util.dao import DAO
+
+
+@pytest.fixture
+def sut():
+    """
+    Fixture for integration testing DAO.create with MongoDB.
+
+    A unique test collection is created for this test run.
+    The collection is removed after the test, so production data is not disturbed.
+    """
+
+    test_collection_name = f"test_create_{uuid.uuid4().hex}"
+
+    test_validator = {
+        "$jsonSchema": {
+            "bsonType": "object",
+            "required": ["name"],
+            "properties": {
+                "name": {"bsonType": "string"}
+            }
+        }
+    }
+
+    with patch("src.util.dao.getValidator") as mock_get_validator:
+        mock_get_validator.return_value = test_validator
+
+        dao = DAO(test_collection_name)
+
+        yield dao
+
+        dao.drop()
+
+
+def test_create_valid_object(sut):
+    """
+    A valid object that follows the validator should be created successfully.
+    """
+
+    valid_data = {"name": "Levin"}
+
+    result = sut.create(valid_data)
+
+    assert "_id" in result
+    assert result["name"] == "Levin"
+
+
+def test_create_missing_required_property(sut):
+    """
+    An object without the required property 'name' should be rejected by MongoDB.
+    """
+
+    invalid_data = {"age": 25}
+
+    with pytest.raises(pymongo.errors.WriteError):
+        sut.create(invalid_data)
+
+
+def test_create_wrong_data_type(sut):
+    """
+    An object where 'name' has the wrong data type should be rejected by MongoDB.
+    """
+
+    invalid_data = {"name": 12345}
+
+    with pytest.raises(pymongo.errors.WriteError):
+        sut.create(invalid_data)

--- a/backend/test/demo/test_usercontroller_get_user_by_email.py
+++ b/backend/test/demo/test_usercontroller_get_user_by_email.py
@@ -1,0 +1,124 @@
+import pytest
+from unittest.mock import MagicMock
+
+from src.controllers.usercontroller import UserController
+
+
+@pytest.fixture
+def mocked_dao():
+    return MagicMock()
+
+
+@pytest.fixture
+def controller(mocked_dao):
+    return UserController(dao=mocked_dao)
+
+
+def test_get_user_by_email_returns_registered_user(controller, mocked_dao):
+    """
+    Test case 1:
+    A valid email that exists in the system should return the matching user.
+    """
+
+    expected_user = {
+        "firstName": "Jane",
+        "lastName": "Doe",
+        "email": "jane.doe@example.com"
+    }
+
+    mocked_dao.find.return_value = [expected_user]
+
+    result = controller.get_user_by_email("jane.doe@example.com")
+
+    assert result == expected_user
+    mocked_dao.find.assert_called_once()
+
+
+def test_get_user_by_email_returns_none_when_user_does_not_exist(controller, mocked_dao):
+    """
+    Test case 2:
+    A valid email that does not exist should return None.
+    """
+
+    mocked_dao.find.return_value = []
+
+    result = controller.get_user_by_email("missing@example.com")
+
+    assert result is None
+    mocked_dao.find.assert_called_once()
+
+
+def test_get_user_by_email_rejects_empty_email(controller, mocked_dao):
+    """
+    Test case 3:
+    An empty email address should be rejected.
+    The DAO should not be used because the input is invalid.
+    """
+
+    with pytest.raises(ValueError):
+        controller.get_user_by_email("")
+
+    mocked_dao.find.assert_not_called()
+
+
+def test_get_user_by_email_rejects_email_without_domain(controller, mocked_dao):
+    """
+    Test case 4:
+    An email without a domain should be rejected.
+    """
+
+    with pytest.raises(ValueError):
+        controller.get_user_by_email("jane.doe")
+
+    mocked_dao.find.assert_not_called()
+
+
+def test_get_user_by_email_rejects_email_with_space(controller, mocked_dao):
+    """
+    Test case 5:
+    An email containing whitespace should be rejected.
+    """
+
+    with pytest.raises(ValueError):
+        controller.get_user_by_email("jane.doe example.com")
+
+    mocked_dao.find.assert_not_called()
+
+
+def test_get_user_by_email_rejects_none_input(controller, mocked_dao):
+    """
+    Test case 6:
+    None is not a valid email input.
+    """
+
+    with pytest.raises(TypeError):
+        controller.get_user_by_email(None)
+
+    mocked_dao.find.assert_not_called()
+
+
+def test_get_user_by_email_returns_first_user_when_multiple_users_exist(controller, mocked_dao):
+    """
+    Test case 7:
+    If several users are connected to the same email, the method should return the first user.
+    The method should also print a warning message.
+    """
+
+    user_1 = {
+        "firstName": "Jane",
+        "lastName": "Doe",
+        "email": "duplicate@example.com"
+    }
+
+    user_2 = {
+        "firstName": "John",
+        "lastName": "Doe",
+        "email": "duplicate@example.com"
+    }
+
+    mocked_dao.find.return_value = [user_1, user_2]
+
+    result = controller.get_user_by_email("duplicate@example.com")
+
+    assert result == user_1
+    mocked_dao.find.assert_called_once()

--- a/frontend/cypress/e2e/todo.cy.js
+++ b/frontend/cypress/e2e/todo.cy.js
@@ -1,0 +1,128 @@
+describe('R8 - Todo item GUI tests', () => {
+  let uid
+  let name
+  let email
+  let taskTitle
+
+  const videoKey = 'dQw4w9WgXcQ'
+
+  function login() {
+    cy.visit('http://localhost:3000')
+
+    cy.contains('div', 'Email Address')
+      .find('input[type=text]')
+      .type(email)
+
+    cy.get('form')
+      .submit()
+
+    cy.get('h1')
+      .should('contain.text', 'Your tasks, ' + name)
+  }
+
+  function createTaskAndOpenIt() {
+    cy.get('#title')
+      .type(taskTitle)
+
+    cy.get('#url')
+      .type(videoKey)
+
+    cy.get('input[type=submit][value="Create new Task"]')
+      .click()
+
+    // The title overlay exists, but it is hidden with CSS opacity until hover.
+    // Therefore we check that it exists and force-click it.
+    cy.contains('.title-overlay', taskTitle, { timeout: 10000 })
+      .should('exist')
+      .click({ force: true })
+
+    cy.get('.todo-list', { timeout: 10000 })
+      .should('be.visible')
+  }
+
+  beforeEach(function () {
+    const stamp = Date.now()
+
+    email = `todo.test.${stamp}@example.com`
+    name = 'Todo Tester'
+    taskTitle = `Todo task ${stamp}`
+
+    const user = {
+      email: email,
+      firstName: 'Todo',
+      lastName: 'Tester'
+    }
+
+    cy.request({
+      method: 'POST',
+      url: 'http://localhost:5000/users/create',
+      form: true,
+      body: user
+    }).then((response) => {
+      uid = response.body._id.$oid
+    })
+
+    login()
+    createTaskAndOpenIt()
+  })
+
+  it('R8UC1 - creates a new todo item for a task', () => {
+    const todoText = 'Read the article'
+
+    cy.get('input[placeholder="Add a new todo item"]')
+      .type(todoText)
+
+    cy.get('form.inline-form')
+      .submit()
+
+    cy.contains('.todo-item', todoText, { timeout: 10000 })
+      .should('be.visible')
+  })
+
+  it('R8UC2 - toggles a todo item as done', () => {
+    cy.contains('.todo-item', 'Watch video', { timeout: 10000 })
+      .within(() => {
+        cy.get('.checker')
+          .click()
+      })
+
+    cy.contains('.todo-item', 'Watch video')
+      .find('.checker')
+      .should('have.class', 'checked')
+  })
+
+  it('R8UC3 - deletes a todo item from a task', () => {
+    const todoText = 'Todo item to delete'
+
+    // First create a unique todo item so the delete test does not depend on the default item.
+    cy.get('input[placeholder="Add a new todo item"]')
+      .type(todoText)
+
+    cy.get('form.inline-form')
+      .submit()
+
+    cy.contains('.todo-item', todoText, { timeout: 10000 })
+      .should('be.visible')
+
+    // Then delete the todo item.
+    cy.contains('.todo-item', todoText)
+      .within(() => {
+        cy.get('.remover')
+          .click()
+      })
+
+    // The todo item should no longer be visible in the GUI.
+    cy.contains('.todo-item', todoText)
+      .should('not.exist')
+  })
+
+  afterEach(function () {
+    if (uid) {
+      cy.request({
+        method: 'DELETE',
+        url: `http://localhost:5000/users/${uid}`,
+        failOnStatusCode: false
+      })
+    }
+  })
+})


### PR DESCRIPTION
This PR fixes get_user_by_email so that it returns None when no user is found. This matches the method documentation and makes the backend unit tests pass